### PR TITLE
Fix the state-space diffuse tolerance: an absolute floor on a scaled variance

### DIFF
--- a/crates/tsecon-arima/tests/cov_accuracy.rs
+++ b/crates/tsecon-arima/tests/cov_accuracy.rs
@@ -13,6 +13,12 @@
 //!   9.8e-9 to 9.8e5. This is the test that would have caught the
 //!   absolute-floored `sigma2` step, which was 4.6% wrong at
 //!   `sigma2 = 9.8e-5` and silent about it.
+//! * [`bse_is_exact_far_below_the_old_absolute_floor`] — the same closed
+//!   forms plus the `loglik(c y) = loglik(y) - n ln c` identity, carried
+//!   down to `sigma2 = 9.8e-19`. This is the test that would have caught
+//!   the state-space filter's absolute variance floor, which discarded
+//!   every observation below `sigma2 ~ 1e-10` and returned `loglik = 0.0`
+//!   as a success.
 //! * [`css_standard_errors_match_ols_on_the_conditional_sample`] — the
 //!   CSS branch of the covariance dispatch, against the OLS closed form
 //!   for the conditional likelihood. This one has teeth: the exact-MLE
@@ -70,12 +76,14 @@ fn rw_drift_mle(y: &[f64]) -> (f64, f64, f64) {
 /// 4.6e-2 relative error with no error and no NaN. Measured worst case
 /// with the log-scale step, over the whole sweep: 4.6e-7.
 ///
-/// The lower end stops at `sigma2 ~ 1e-8` for a reason outside this
-/// crate: the state-space filter drops observations whose prediction
-/// variance is below `1e-10` (`tsecon_ssm::filter::TOLERANCE_DIFFUSE`, an
-/// absolute threshold), so below that the log-likelihood itself goes
-/// numerically constant. The sweep asserts that this shows up as an
-/// *error* and never as a number.
+/// The lower end used to stop at `sigma2 ~ 1e-8` for a reason outside this
+/// crate: the state-space filter compared each prediction variance against
+/// an *absolute* `1e-10` floor and dropped everything below it, so beneath
+/// that the log-likelihood went numerically constant and this sweep could
+/// not be extended. That floor is now relative to the variance's own scale
+/// (`tsecon_ssm::filter::TOLERANCE_RANK`), so the likelihood is real all
+/// the way down; [`bse_is_exact_far_below_the_old_absolute_floor`] carries
+/// the sweep another ten decades to `sigma2 ~ 9.8e-19`.
 #[test]
 fn bse_is_scale_free_across_fourteen_decades_of_sigma2() {
     let base = random_walk_with_drift(7, 200);
@@ -122,20 +130,100 @@ fn bse_is_scale_free_across_fourteen_decades_of_sigma2() {
         bse[1]
     );
 
-    // Below the filter's absolute variance floor the likelihood is
-    // numerically constant. That must be an error, never a number.
+    // Below the old absolute variance floor the likelihood used to go
+    // numerically constant, and this assertion used to demand an error.
+    // With the relative floor the likelihood is real there, so the
+    // standard errors are simply correct — see
+    // `bse_is_exact_far_below_the_old_absolute_floor` for the full sweep.
     let y: Vec<f64> = base.iter().map(|v| v * 1e-6).collect();
-    let (c, s2, _) = rw_drift_mle(&y);
-    assert!(s2 < 1e-10, "expected sigma2 under the filter floor: {s2:e}");
-    let err = spec.at_params(&y, &[c, s2]).unwrap().bse().unwrap_err();
+    let (c, s2, n) = rw_drift_mle(&y);
     assert!(
-        matches!(err, ArimaError::CovarianceFailed { .. }),
-        "a numerically flat likelihood produced {err:?}, not an error"
+        s2 < 1e-10,
+        "expected sigma2 under the old filter floor: {s2:e}"
     );
+    let bse = spec
+        .at_params(&y, &[c, s2])
+        .unwrap()
+        .bse()
+        .expect("a sub-1e-10 sigma2 is filterable, not a flat likelihood");
+    let want = (2.0 * s2 * s2 / n).sqrt();
     assert!(
-        err.to_string().contains("Rescale"),
-        "the error must name the fix: {err}"
+        (bse[1] - want).abs() <= 5e-6 * want,
+        "se(sigma2) at sigma2 = {s2:e}: {} vs the closed form {want}",
+        bse[1]
     );
+}
+
+/// **The regression test for the silent `loglik = 0.0`.** The exact
+/// log-likelihood of ARIMA(0,1,0)+c is a closed form in the series scale:
+/// multiplying `y` by `c` multiplies the MLE `sigma2` by `c^2` and shifts
+/// the log-likelihood by exactly `-n ln c`, where `n` is the number of
+/// first differences. Nothing external is needed to check it.
+///
+/// Before the fix, the state-space filter compared each prediction
+/// variance against an absolute `1e-10`. At `sigma2 ~ 1e-13` that
+/// discarded *every* observation, and `arima` reported `loglik = 0.0` as a
+/// success — a meaningless optimum indistinguishable from a real one. The
+/// sweep here runs `sigma2` from `9.8e5` down to `9.8e-19`, twenty-four
+/// decades, and asserts the likelihood sits on the closed-form line the
+/// whole way. Under the old floor everything from `k = 5` on returned
+/// exactly `0.0`, missing the line by thousands of nats.
+///
+/// The standard errors are checked alongside, because a likelihood that is
+/// merely *nonzero* but wrong would still pass a nonzero-check.
+#[test]
+fn bse_is_exact_far_below_the_old_absolute_floor() {
+    let base = random_walk_with_drift(7, 200);
+    let spec = ArimaSpec::new(0, 1, 0).unwrap().with_constant(true);
+
+    let (c0, _, n) = rw_drift_mle(&base);
+    let (_, s2_0, _) = rw_drift_mle(&base);
+    let ll0 = spec
+        .loglike(&base, &[c0, s2_0])
+        .expect("the unit-scale likelihood is well defined");
+
+    let mut worst_ll = 0.0_f64;
+    let mut worst_bse = 0.0_f64;
+    // scale 1e-9 .. 1e3 puts sigma2 in 9.8e-19 .. 9.8e5.
+    for k in -3..=9 {
+        let scale = 10f64.powi(-k);
+        let y: Vec<f64> = base.iter().map(|v| v * scale).collect();
+        let (c, s2, _) = rw_drift_mle(&y);
+
+        let ll = spec
+            .loglike(&y, &[c, s2])
+            .unwrap_or_else(|e| panic!("sigma2 = {s2:e}: loglike failed with {e}"));
+        assert_ne!(
+            ll, 0.0,
+            "sigma2 = {s2:e}: loglik collapsed to exactly 0.0 — every \
+             observation was discarded, which is the absolute-floor defect"
+        );
+
+        // loglik(scale * y) = loglik(y) - n ln(scale).
+        let want_ll = ll0 - n * scale.ln();
+        let rel_ll = (ll - want_ll).abs() / want_ll.abs().max(1.0);
+        worst_ll = worst_ll.max(rel_ll);
+        assert!(
+            rel_ll <= 1e-12,
+            "sigma2 = {s2:e}: loglik {ll} vs the closed form {want_ll} (rel {rel_ll:e})"
+        );
+
+        let bse = spec
+            .at_params(&y, &[c, s2])
+            .unwrap()
+            .bse()
+            .unwrap_or_else(|e| panic!("sigma2 = {s2:e}: bse failed with {e}"));
+        let want = [(s2 / n).sqrt(), (2.0 * s2 * s2 / n).sqrt()];
+        for (i, (&got, &w)) in bse.iter().zip(&want).enumerate() {
+            let rel = (got - w).abs() / w;
+            worst_bse = worst_bse.max(rel);
+            assert!(
+                rel <= 5e-6,
+                "sigma2 = {s2:e}: bse[{i}] = {got} vs the closed form {w} (rel {rel:e})"
+            );
+        }
+    }
+    println!("24-decade sweep: worst loglik deviation {worst_ll:e}, worst bse {worst_bse:e}");
 }
 
 /// OLS of `y_t` on `[1, y_{t-1}, ..., y_{t-p}]` over `t = p..n`, with the

--- a/crates/tsecon-ssm/src/dense.rs
+++ b/crates/tsecon-ssm/src/dense.rs
@@ -93,6 +93,49 @@ pub(crate) fn frob_sq(m: MatRef<'_, f64>) -> f64 {
     s
 }
 
+/// Cancellation-free bound on a quadratic form:
+/// `|z|' |M| |z| = sum_{a,b} |z_a| |z_b| |M_ab|`.
+///
+/// This is the reference scale the filter measures `F = z' M z (+ H)`
+/// against when asking "is this value a variance, or is it cancellation
+/// noise?". It dominates `|z' M z|` term by term (triangle inequality), so
+/// it is exactly the magnitude the quadratic form would have reached had no
+/// cancellation occurred — and `F / (|z|' |M| |z|)` is therefore the
+/// fraction of that magnitude that survived the sum.
+///
+/// Two properties earn it the job:
+///
+/// * **direction-aware.** Only the entries of `M` that `z` actually touches
+///   enter, weighted by how hard `z` touches them. A state the observation
+///   equation does not load on (`z_a = 0`) contributes nothing, no matter
+///   how large its variance. The cruder `||z||_1^2 max_j M_jj` fails this:
+///   one large-variance nuisance state raises the bar for every element.
+/// * **cancellation-bounding.** It still dominates the intermediate
+///   `M z` products, so it rejects a `F` that is small only because the
+///   terms of `z' M z` cancelled — which is the failure the test exists to
+///   catch. (`dot(|z|, |M z|)` would not: cancellation inside `M z` itself
+///   would already have shrunk it.)
+///
+/// Both scale as `c^2` when `M` does, so the test built on this is
+/// invariant to rescaling the data, and invariant to rescaling any single
+/// state coordinate (which rescales `z_a` and the `a`-th row/column of `M`
+/// by reciprocal factors).
+pub(crate) fn abs_quad_form(z: &[f64], m: MatRef<'_, f64>) -> f64 {
+    debug_assert_eq!(m.nrows(), z.len());
+    debug_assert_eq!(m.ncols(), z.len());
+    let mut s = 0.0;
+    for (b, zb) in z.iter().enumerate() {
+        if *zb == 0.0 {
+            continue;
+        }
+        let zb = zb.abs();
+        for (a, za) in z.iter().enumerate() {
+            s += za.abs() * zb * m[(a, b)].abs();
+        }
+    }
+    s
+}
+
 /// In-place exact symmetrization `M <- (M + M') / 2` of a square matrix.
 ///
 /// Cheap hygiene applied after covariance updates so downstream code never

--- a/crates/tsecon-ssm/src/error.rs
+++ b/crates/tsecon-ssm/src/error.rs
@@ -58,6 +58,30 @@ pub enum SsmError {
         /// Name of the operation.
         what: &'static str,
     },
+    /// Every observed element of `y` was numerically uninformative, so the
+    /// effective sample is empty and the log-likelihood is an empty sum.
+    ///
+    /// The filter skips an element whose prediction variance `F` is below
+    /// the relative rank tolerance — it cannot be told apart from
+    /// cancellation noise. When *every* observed element is skipped the
+    /// likelihood would come back as exactly `0.0`, which is not a small
+    /// number but the absence of one; returning it as a success would let
+    /// a caller optimize a constant and report the result as a fit.
+    ///
+    /// The cause is never the *scale* of the data or of a state: the rank
+    /// test compares `F` against `|Z_i| |P| |Z_i|' + H_ii`, which carries
+    /// the same units and the same direction, so rescaling `y` — or
+    /// rescaling one state coordinate — cannot move this boundary. What
+    /// does move it is the model:
+    ///
+    /// * the observation equation loads on nothing that varies — `Z` is
+    ///   zero, or every state it does load on has zero variance from every
+    ///   source (`H_ii = 0` with a zero `P_1` and a zero `R Q R'` in those
+    ///   coordinates);
+    /// * or `Z_i P Z_i' + H_ii` is a near-exact cancellation, which means
+    ///   the model is deterministic along `Z_i` to within roundoff of the
+    ///   magnitudes it was assembled from.
+    NoInformation,
 }
 
 impl fmt::Display for SsmError {
@@ -93,6 +117,26 @@ impl fmt::Display for SsmError {
                 f,
                 "{what} does not support exact-diffuse initialization; \
                  use the univariate filtering path"
+            ),
+            Self::NoInformation => write!(
+                f,
+                "every observed element of y was numerically uninformative: \
+                 its prediction variance F = Z_i P Z_i' + H_ii was \
+                 indistinguishable from zero next to |Z_i| |P| |Z_i|' + \
+                 H_ii, the magnitude that same sum would have had without \
+                 cancellation. The effective sample is therefore empty and \
+                 the log-likelihood is an empty sum rather than a number. \
+                 The test carries the units and the direction of F, so \
+                 rescaling y will not change this, and neither will \
+                 rescaling a state — look at the model along the row Z_i \
+                 instead. Either it loads on nothing that varies (a zero \
+                 row of Z, or zero H_ii together with zero initial and \
+                 state variance in the states Z_i does load on — the \
+                 degenerate model), or Z_i P Z_i' is a near-total \
+                 cancellation, which says the model is deterministic along \
+                 Z_i to within roundoff of the numbers it was assembled \
+                 from. States in wildly different units make the second \
+                 case easy to hit by accident"
             ),
         }
     }

--- a/crates/tsecon-ssm/src/filter.rs
+++ b/crates/tsecon-ssm/src/filter.rs
@@ -47,28 +47,98 @@
 //!
 //! while an element with `F_inf = 0` gets the ordinary update above. The
 //! diffuse period ends at the first `t` whose incoming `P_inf` is
-//! numerically zero; conventions (tolerances, the `-(ln 2*pi + ln F_inf)/2`
-//! diffuse likelihood contribution) match statsmodels'
-//! `use_exact_diffuse=True` filter exactly, so log-likelihoods are directly
-//! comparable. (Cross-package caution: some implementations, e.g. following
-//! Francke, Koopman & de Vos 2010, omit constants from the diffuse
-//! contribution.)
+//! numerically zero; the `-(ln 2*pi + ln F_inf)/2` diffuse likelihood
+//! contribution matches statsmodels' `use_exact_diffuse=True` filter, so
+//! log-likelihoods are directly comparable. (Cross-package caution: some
+//! implementations, e.g. following Francke, Koopman & de Vos 2010, omit
+//! constants from the diffuse contribution.)
+//!
+//! # Numerical-rank decisions
+//!
+//! Three decisions in the recursions above ask "is this quantity zero?":
+//! whether `P_inf` has washed out, whether `F_inf` is positive (diffuse
+//! branch), and whether `F_*` is positive (informative element). The two
+//! `F` tests are asked *relative to the scale of the quantity being
+//! tested*; the `P_inf` washout test is absolute, and deliberately so —
+//! see [`TOLERANCE_RANK`], which sets out why the three are not treated
+//! alike.
+//!
+//! An absolute floor on `F_*` is a units bug: `F_*` is a variance in the
+//! units of `y` squared, so a floor of `1e-10` silently declares every
+//! observation uninformative for any series whose variance happens to sit
+//! below it, and the filter then returns `loglik = 0` as though it had
+//! succeeded. The relative test is invariant to rescaling `y`, which is the
+//! property the closed-form `loglik(c y) = loglik(y) - n ln c` identity in
+//! `tests/scale.rs` pins.
+//!
+//! Getting *relative to what* right is the other half. The reference scale
+//! must be direction-aware: `F_{*,i}` is a variance along the single
+//! direction `Z_i`, so measuring it against a scale that sees states `Z_i`
+//! does not load on lets an unobserved nuisance state — a regression
+//! coefficient in different units, an approximate-diffuse prior of `1e6` —
+//! veto every observation in the sample. The reference used here is the
+//! cancellation-free quadratic form `|Z_i|' |P| |Z_i|`
+//! ([`abs_quad_form`](crate::dense::abs_quad_form)), which is both
+//! direction-aware and invariant to rescaling an individual state
+//! coordinate. `tests/scale.rs` pins both invariances on multi-state
+//! models.
 
 use tsecon_linalg::faer::{Mat, MatRef};
 use tsecon_linalg::jittered_cholesky;
 
 use crate::dense::{
-    axpy, chol_solve, dot, frob_sq, mat_vec, outer_sub, row_to_vec, sandwich, symmetrize_in_place,
+    abs_quad_form, axpy, chol_solve, dot, frob_sq, mat_vec, outer_sub, row_to_vec, sandwich,
+    symmetrize_in_place,
 };
 use crate::error::SsmError;
 use crate::model::LinearGaussianSSM;
 
-/// Numerical tolerance for the diffuse recursions, matching statsmodels'
-/// `tolerance_diffuse`: a time step is diffuse while `||P_inf||_F^2`
-/// exceeds it, an element takes the diffuse update while `F_inf` exceeds
-/// it, and an element with `F_* <= tolerance` is treated as carrying no
-/// information (skipped, like a missing value).
-pub(crate) const TOLERANCE_DIFFUSE: f64 = 1e-10;
+/// Tolerance for the filter's three numerical-rank decisions.
+///
+/// The two `F` tests are *relative*: each compares a computed nonnegative
+/// variance against this fraction of a reference scale carrying the same
+/// units, so both are invariant to rescaling the data and to rescaling any
+/// individual state coordinate. The washout test is *absolute*, because the
+/// quantity it tests is dimensionless. In detail:
+///
+/// * **informative element.** An element carries information while
+///   `F_* > TOLERANCE_RANK * (|Z_i|' |P_*| |Z_i| + H_ii)`; otherwise it is
+///   skipped exactly like a missing value. The reference is the magnitude
+///   `Z_i P_* Z_i' + H_ii` would have had with no cancellation, so the test
+///   reads "did at least `1e-10` of the available magnitude survive the
+///   sum?".
+/// * **diffuse element.** An element takes the diffuse update while
+///   `F_inf > TOLERANCE_RANK * |Z_i|' |P_inf| |Z_i|`, the same test applied
+///   to the diffuse part.
+/// * **diffuse period.** A step is diffuse while `||P_inf,t||_F^2 >
+///   TOLERANCE_RANK`, an **absolute** threshold.
+///
+/// ## Why the washout test is absolute, and the other two are not
+///
+/// The "three uses, one treatment" symmetry is the wrong instinct here, and
+/// it is worth recording why. `F_*` and `F_inf` are *variances*: `F_*` is
+/// in units of `y` squared and `F_inf` inherits the units of the diffuse
+/// prior, so an absolute floor on either is a units error — that is the
+/// defect this tolerance was rewritten to fix. `P_inf` is not a variance.
+/// It is a **rank indicator** for the limit `P_1 = P_* + kappa P_inf`,
+/// `kappa -> infinity`: it never touches `y`, `H` or `Q`, it is built as a
+/// 0/1 diagonal (`I`, or the flagged states of a `Mixed` initialization),
+/// and it is only ever asked how many diffuse directions are left. It is
+/// `O(1)` by construction, so there was no units bug at that site.
+///
+/// Normalizing it by `||P_inf,1||_F^2` — the diffuse prior's *total*
+/// initial size — would only add a failure mode: for a non-uniform prior
+/// like `diag(1e10, 1)` a still-live diffuse direction of size `1` is
+/// `1e-20` of the total and would be declared washed out, ending the
+/// diffuse period early and silently. Absolute is correct here.
+///
+/// The value `1e-10` is inherited from statsmodels' `tolerance_diffuse`,
+/// which applies it as an absolute floor everywhere. On unit-scale data the
+/// two agree to the last bit (`tests/golden.rs` is the proof); they part
+/// company only where the absolute floor is wrong, namely when a variance's
+/// own scale is below `1e-10` — small-variance data — or far above it,
+/// where the absolute floor is too permissive about cancellation.
+pub(crate) const TOLERANCE_RANK: f64 = 1e-10;
 
 /// `ln(2 pi)`, the per-element likelihood constant.
 #[inline]
@@ -84,6 +154,11 @@ pub(crate) struct ObsStep {
     /// missing (NaN) and numerically singular elements are both skipped
     /// by filter and smoother alike.
     pub(crate) observed: bool,
+    /// True when the filter took the *exact-diffuse* branch for this
+    /// element. Recorded rather than re-derived, so the smoother replays
+    /// the branch the filter actually took instead of re-running a
+    /// threshold comparison that could disagree with it.
+    pub(crate) diffuse: bool,
     /// Prediction error `v_{t,i}`.
     pub(crate) v: f64,
     /// Finite innovation variance `F_{*,t,i}` (includes `H_ii`).
@@ -102,6 +177,7 @@ impl ObsStep {
     fn skipped() -> Self {
         ObsStep {
             observed: false,
+            diffuse: false,
             v: 0.0,
             f_star: 0.0,
             f_inf: 0.0,
@@ -235,14 +311,22 @@ pub fn filter_univariate(
     };
     // Once P_inf collapses to (numerical) zero it stays zero, so the
     // diffuse period is a contiguous prefix; the flag makes that explicit.
-    let mut in_diffuse = true;
+    // A proper (non-diffuse) initialization has P_inf = 0 exactly, so the
+    // diffuse machinery is inert for the whole sample.
+    let mut in_diffuse = frob_sq(p_inf.as_ref()) > 0.0;
+    // Observed (non-NaN) elements, and how many of them carried
+    // information. An empty effective sample is an error, not a zero.
+    let mut n_observed = 0usize;
+    let mut n_informative = 0usize;
 
     for t in 0..n {
         let z = model.z().at(t);
         let h = model.h().at(t);
         let tr = model.t().at(t);
 
-        let diffuse = in_diffuse && frob_sq(p_inf.as_ref()) > TOLERANCE_DIFFUSE;
+        // Absolute, on purpose: P_inf is a dimensionless rank indicator,
+        // not a variance (see TOLERANCE_RANK).
+        let diffuse = in_diffuse && frob_sq(p_inf.as_ref()) > TOLERANCE_RANK;
         if diffuse {
             out.d_diffuse += 1;
         } else {
@@ -261,20 +345,37 @@ pub fn filter_univariate(
                 out.steps.push(ObsStep::skipped());
                 continue;
             }
+            n_observed += 1;
             let zi = row_to_vec(z, i);
             let v = yti - model.obs_intercept()[i] - dot(&zi, &a);
             let m_star = mat_vec(p_star.as_ref(), &zi);
             // Clamp roundoff-negative variances to zero (statsmodels does
             // the same) before branching.
             let f_star = (dot(&zi, &m_star) + h[(i, i)]).max(0.0);
-            let (f_inf, m_inf) = if diffuse {
+            // Reference scale for F_*: the magnitude Z_i P_* Z_i' + H_ii
+            // would have had if nothing in the sum cancelled. F_* below
+            // TOLERANCE_RANK of this is cancellation noise; F_* above it is
+            // a real (if tiny) variance. Direction-aware — a state Z_i does
+            // not load on contributes nothing, however large its variance.
+            let f_star_scale = abs_quad_form(&zi, p_star.as_ref()) + h[(i, i)];
+            let (f_inf, m_inf, f_inf_scale) = if diffuse {
                 let mi = mat_vec(p_inf.as_ref(), &zi);
-                (dot(&zi, &mi).max(0.0), mi)
+                let scale = abs_quad_form(&zi, p_inf.as_ref());
+                (dot(&zi, &mi).max(0.0), mi, scale)
             } else {
-                (0.0, Vec::new())
+                (0.0, Vec::new(), 0.0)
             };
 
-            if f_inf > TOLERANCE_DIFFUSE {
+            // Each reference scale is a sum of nonnegative terms that
+            // dominate the corresponding terms of the quantity it is
+            // compared against (`|z' P z| <= |z|' |P| |z|`; `H` is PSD), so
+            // both are nonnegative and passing `f > TOLERANCE_RANK * scale`
+            // implies `f > 0` — including when the scale is itself zero,
+            // where the test degenerates to exactly `f > 0`. The branches
+            // below therefore never divide by a zero variance.
+            debug_assert!(f_star_scale >= 0.0 && f_inf_scale >= 0.0);
+
+            if f_inf > TOLERANCE_RANK * f_inf_scale {
                 // Exact-diffuse element update (Koopman & Durbin 2003).
                 let k0: Vec<f64> = m_inf.iter().map(|x| x / f_inf).collect();
                 let f12 = -f_star / f_inf;
@@ -290,22 +391,26 @@ pub fn filter_univariate(
                 // P_inf <- P_inf L0' = P_inf - M_inf K0'.
                 outer_sub(&mut p_inf, &m_inf, &k0);
                 out.loglik -= 0.5 * (ln2pi + f_inf.ln());
+                n_informative += 1;
                 out.steps.push(ObsStep {
                     observed: true,
+                    diffuse: true,
                     v,
                     f_star,
                     f_inf,
                     m_star,
                     m_inf,
                 });
-            } else if f_star > TOLERANCE_DIFFUSE {
+            } else if f_star > TOLERANCE_RANK * f_star_scale {
                 // Standard scalar update (Koopman & Durbin 2000).
                 let k0: Vec<f64> = m_star.iter().map(|x| x / f_star).collect();
                 axpy(&mut a, v, &k0);
                 outer_sub(&mut p_star, &m_star, &k0);
                 out.loglik -= 0.5 * (ln2pi + f_star.ln() + v * v / f_star);
+                n_informative += 1;
                 out.steps.push(ObsStep {
                     observed: true,
+                    diffuse: false,
                     v,
                     f_star,
                     f_inf: 0.0,
@@ -338,6 +443,15 @@ pub fn filter_univariate(
         p_inf = sandwich(tr, p_inf.as_ref());
         symmetrize_in_place(&mut p_star);
         symmetrize_in_place(&mut p_inf);
+    }
+
+    // Every observed element was skipped as uninformative: the returned
+    // log-likelihood would be exactly 0.0 — not a small number, an *empty
+    // sum* — and reporting that as a success is a silent wrong answer.
+    // (An all-missing `y` is not this case: it is an explicit, documented
+    // request to run the recursions with nothing to condition on.)
+    if n_observed > 0 && n_informative == 0 {
+        return Err(SsmError::NoInformation);
     }
 
     out.predicted_state.push(a);

--- a/crates/tsecon-ssm/src/smoother.rs
+++ b/crates/tsecon-ssm/src/smoother.rs
@@ -63,7 +63,7 @@ use tsecon_linalg::faer::{Mat, MatRef};
 
 use crate::dense::{axpy, mat_t_vec, mat_vec, outer_scaled, sandwich_t, symmetrize_in_place};
 use crate::error::SsmError;
-use crate::filter::{filter_univariate, FilterOutput, TOLERANCE_DIFFUSE};
+use crate::filter::{filter_univariate, FilterOutput};
 use crate::model::LinearGaussianSSM;
 
 /// Output of the univariate state smoother: smoothed moments plus the
@@ -123,7 +123,7 @@ pub fn smooth_univariate(
             }
             let zi: Vec<f64> = (0..m).map(|j| z[(i, j)]).collect();
 
-            if step.f_inf > TOLERANCE_DIFFUSE {
+            if step.diffuse {
                 // Exact-diffuse element (only occurs while t < d_diffuse).
                 let f1 = 1.0 / step.f_inf;
                 let f2 = -step.f_star * f1 * f1;

--- a/crates/tsecon-ssm/tests/scale.rs
+++ b/crates/tsecon-ssm/tests/scale.rs
@@ -1,0 +1,693 @@
+//! Scale invariance of the log-likelihood, and the empty-sample error.
+//!
+//! `golden.rs` pins agreement with statsmodels at one scale. It cannot see
+//! a units bug, because every fixture is unit-scale: the Nile data are
+//! thousands of cubic metres and the fitted variances are in the thousands.
+//! The tests here vary the *scale* of the same problem and check the
+//! log-likelihood against the closed form it must obey.
+//!
+//! # The closed form
+//!
+//! The filter accumulates one term per informative element,
+//! `-(ln 2*pi + ln F + v^2 / F) / 2`. Rescale the observations by `c > 0`
+//! and rescale every variance in the model by `c^2` (`H`, `Q`, `P_1`) and
+//! every location by `c` (`a_1`, the intercepts): then every `v -> c v` and
+//! every `F -> c^2 F`, so `v^2 / F` is unchanged and `ln F -> ln F + 2 ln c`.
+//! Each term therefore drops by exactly `ln c`, and
+//!
+//! ```text
+//! loglik(c y; scaled model) = loglik(y; model) - n_informative * ln c.
+//! ```
+//!
+//! This is the Jacobian of the change of variables `y -> c y`, so it holds
+//! to the last few bits and needs no external package to check against.
+//!
+//! One wrinkle, and it is the interesting one. Under *exact-diffuse*
+//! initialization the diffuse prior `P_inf = I` is a limit
+//! (`P_1 = P_* + kappa P_inf`, `kappa -> infinity`), not a variance, so it
+//! does **not** scale with `c`. A diffuse element contributes
+//! `-(ln 2*pi + ln F_inf) / 2` with `F_inf = Z P_inf Z'`, which is
+//! scale-free — those elements do not pick up the `-ln c`. The identity
+//! above is therefore exact with a proper (`Known`) initialization, and
+//! carries a correction of exactly one term per diffuse element under
+//! `Diffuse`. Both variants are asserted below; getting this wrong in
+//! either direction would look like a scale bug.
+//!
+//! # What these tests would have caught
+//!
+//! Before the fix, `F_*` was compared against an *absolute* `1e-10`. Any
+//! series whose prediction variances fell below that had its observations
+//! discarded as uninformative, and the two failure modes are both silent:
+//!
+//! * **partial.** When only the converged `F` falls under the floor, the
+//!   first few observations are kept and the rest are dropped, so `loglik`
+//!   comes back as a plausible finite number computed from a truncated
+//!   sample. Measured on the sweep below at `c = 1e-5`: `772.13` against a
+//!   true `1581.34`, wrong by 51%, with no error and no NaN. This one is
+//!   worse than the collapse, because nothing about the output looks odd.
+//! * **total.** When every `F` falls under the floor, every observation is
+//!   dropped and `loglik` is exactly `0.0` — an empty sum returned as a
+//!   success, which a caller can optimize and report as a fit.
+//!
+//! [`loglik_shifts_by_minus_n_ln_c_under_rescaling`] catches both, because
+//! it checks the *value* against the closed-form line rather than checking
+//! that the filter returned without complaining.
+//!
+//! # Why the single-state tests are not enough
+//!
+//! Every test above uses `m = 1`. That is a blind spot, and it let a second
+//! units bug through: with one state, `||Z||_1^2 max_j P_jj` and
+//! `|Z|' |P| |Z|` are the *same number*, so a reference scale that looks at
+//! states the observation equation does not load on is indistinguishable
+//! from one that does not. The first version of the relative tolerance used
+//! the former, and on `m = 1` models — these ones — it was exactly right.
+//!
+//! On `m >= 2` it is not. `F_{*,i}` is a variance along the single
+//! direction `Z_i`; measuring it against the largest variance over *all*
+//! states lets one large-variance state veto every observation in the
+//! sample, and states in different units are routine (a regression
+//! coefficient beside a level, an approximate-diffuse prior of `1e6`
+//! beside a unit-scale level). The three failures that produced —
+//! a nuisance state vetoing observations, the same on the diffuse side, and
+//! the partial silent drop coming back through a *decaying* nuisance state
+//! — are pinned by the four multi-state tests at the end of this file:
+//!
+//! * [`a_nuisance_state_cannot_change_the_likelihood`] and
+//!   [`a_decaying_nuisance_state_cannot_silently_drop_observations`] —
+//!   a state `Z` does not load on, and `T` cannot feed into the states it
+//!   does, is provably irrelevant to `y`; the likelihood must not move
+//!   however large its variance.
+//! * [`loglik_is_invariant_to_rescaling_one_state_coordinate`] — two models
+//!   related by `alpha~ = S^{-1} alpha`, `S = diag(1, x)`, are the same
+//!   model written in different units, so they must return the same number.
+//! * [`the_diffuse_period_is_invariant_to_rescaling_one_state_coordinate`]
+//!   — the same for the *length* of the diffuse period, which is a rank
+//!   count and cannot depend on the units the states are written in.
+//!
+//! These four are the tests that would have caught the defect.
+
+mod common;
+
+use common::Lcg;
+use tsecon_linalg::faer::Mat;
+use tsecon_ssm::{Initialization, LinearGaussianSSM, SsmError};
+
+/// A deterministic unit-scale local-level series: a random-walk level plus
+/// observation noise, from the seeded LCG (no dependency on `tsecon-rng`).
+fn local_level_series(seed: u64, n: usize) -> Vec<f64> {
+    let mut rng = Lcg::new(seed);
+    let mut level = 0.0;
+    (0..n)
+        .map(|_| {
+            level += 0.7 * rng.symmetric();
+            level + 0.4 * rng.symmetric()
+        })
+        .collect()
+}
+
+/// A slice as an `n x 1` observation matrix.
+fn col(y: &[f64]) -> Mat<f64> {
+    Mat::from_fn(y.len(), 1, |i, _| y[i])
+}
+
+/// Local level with a *proper* (`Known`) initialization, every variance
+/// scaled by `c^2` and every location by `c`. No diffuse elements, so the
+/// closed-form shift is exact for all `n` observations.
+fn scaled_known_local_level(c: f64) -> LinearGaussianSSM {
+    let one = Mat::from_fn(1, 1, |_, _| 1.0);
+    LinearGaussianSSM::builder(1, 1, 1)
+        .z(one.clone())
+        .h(Mat::from_fn(1, 1, |_, _| 0.16 * c * c))
+        .t(one.clone())
+        .r(one)
+        .q(Mat::from_fn(1, 1, |_, _| 0.49 * c * c))
+        .initialization(Initialization::Known {
+            a1: vec![0.0],
+            p1: Mat::from_fn(1, 1, |_, _| 2.0 * c * c),
+        })
+        .build()
+        .expect("the scaled local level is a valid model")
+}
+
+/// **The scale sweep.** Over twenty-two decades of prediction variance,
+/// the log-likelihood must sit on the closed-form line
+/// `loglik(c y) = loglik(y) - n ln c` rather than degrading.
+///
+/// The sweep runs `c` from `1e5` down to `1e-6`. This model's steady-state
+/// prediction variance is `F = P + H` with `P` the positive root of
+/// `P^2 - Q P - Q H = 0`, so `F ~ 0.777 c^2`: the sweep spans `F` from
+/// about `7.8e9` down to `7.8e-13`, straddling the old absolute `1e-10`
+/// floor from both sides. The first point the old floor got wrong is
+/// `c = 1e-5` (`F ~ 7.8e-11`), and it got it wrong *partially* — `P_1`
+/// starts at `2e-10`, above the floor, so the opening observations were
+/// kept and the rest dropped, returning `772.13` where the truth is
+/// `1581.34`. Deeper in, the sample empties completely and the answer is
+/// exactly `0.0`.
+#[test]
+fn loglik_shifts_by_minus_n_ln_c_under_rescaling() {
+    let y = local_level_series(11, 150);
+    let n = y.len() as f64;
+
+    let base = scaled_known_local_level(1.0)
+        .loglike(col(&y).as_ref())
+        .expect("the unit-scale likelihood is well defined");
+    assert!(base.is_finite());
+
+    let mut worst: f64 = 0.0;
+    for k in -5..=6 {
+        let c = 10f64.powi(-k);
+        let ys: Vec<f64> = y.iter().map(|v| v * c).collect();
+        let got = scaled_known_local_level(c)
+            .loglike(col(&ys).as_ref())
+            .unwrap_or_else(|e| panic!("c = {c:e}: the filter failed with {e}"));
+        let want = base - n * c.ln();
+
+        assert!(got.is_finite(), "c = {c:e}: loglik is not finite ({got})");
+        assert_ne!(
+            got, 0.0,
+            "c = {c:e}: loglik collapsed to exactly 0.0 — every element was \
+             skipped, which is the absolute-floor defect"
+        );
+        // Relative to the magnitude of the shift itself, so the tolerance
+        // does not quietly loosen as |loglik| grows with the scale.
+        let rel = (got - want).abs() / want.abs().max(1.0);
+        worst = worst.max(rel);
+        assert!(
+            rel <= 1e-12,
+            "c = {c:e}: loglik {got} vs the closed form {want} (rel {rel:e})"
+        );
+    }
+    println!("known-init scale sweep: worst relative deviation {worst:e}");
+}
+
+/// The same identity under *exact-diffuse* initialization, where it is not
+/// the same identity: the one diffuse element contributes a scale-free
+/// `-(ln 2*pi + ln F_inf) / 2`, so the shift is `-(n - 1) ln c`, not
+/// `-n ln c`.
+///
+/// This pins two things at once — that the diffuse contribution really is
+/// scale-free, and that *which* elements take the diffuse branch does not
+/// drift with the scale of the data (`d_diffuse` is asserted constant).
+#[test]
+fn diffuse_loglik_shifts_by_minus_n_minus_d_ln_c() {
+    let y = local_level_series(23, 120);
+    let n = y.len() as f64;
+
+    let base_out = LinearGaussianSSM::local_level(0.16, 0.49)
+        .unwrap()
+        .filter(col(&y).as_ref())
+        .expect("the unit-scale diffuse filter succeeds");
+    // p = 1, so one diffuse period is exactly one diffuse element.
+    assert_eq!(base_out.d_diffuse, 1);
+
+    for k in -5..=6 {
+        let c = 10f64.powi(-k);
+        let ys: Vec<f64> = y.iter().map(|v| v * c).collect();
+        let out = LinearGaussianSSM::local_level(0.16 * c * c, 0.49 * c * c)
+            .unwrap()
+            .filter(col(&ys).as_ref())
+            .unwrap_or_else(|e| panic!("c = {c:e}: the diffuse filter failed with {e}"));
+
+        assert_eq!(
+            out.d_diffuse, 1,
+            "c = {c:e}: the diffuse period changed length with the data scale"
+        );
+        let want = base_out.loglik - (n - 1.0) * c.ln();
+        let rel = (out.loglik - want).abs() / want.abs().max(1.0);
+        assert!(
+            rel <= 1e-12,
+            "c = {c:e}: diffuse loglik {} vs the closed form {want} (rel {rel:e})",
+            out.loglik
+        );
+    }
+}
+
+/// The single case the bug report reproduced: a series whose prediction
+/// variances all sit below the old `1e-10` floor. It must not come back as
+/// a successful `0.0`.
+///
+/// The assertion is not merely "nonzero" — the value is checked against the
+/// closed form, so a wrong-but-nonzero answer fails too.
+#[test]
+fn a_tiny_variance_series_returns_a_correct_loglik_not_zero() {
+    let y = local_level_series(5, 80);
+    let n = y.len() as f64;
+    let c = 1e-7; // prediction variances land around 1e-15.
+
+    let base = scaled_known_local_level(1.0)
+        .loglike(col(&y).as_ref())
+        .unwrap();
+    let ys: Vec<f64> = y.iter().map(|v| v * c).collect();
+    let got = scaled_known_local_level(c)
+        .loglike(col(&ys).as_ref())
+        .expect("a small-variance series is filterable, not an error");
+
+    assert_ne!(got, 0.0, "the silent-zero path is back");
+    let want = base - n * c.ln();
+    let rel = (got - want).abs() / want.abs();
+    assert!(
+        rel <= 1e-12,
+        "tiny-variance loglik {got} vs the closed form {want} (rel {rel:e})"
+    );
+    // And it is a large number, so "nonzero" above is not a near-miss.
+    assert!(got > 1000.0, "expected a large positive loglik, got {got}");
+}
+
+/// The smoother rides on the same per-element branch decisions, so it must
+/// survive the same rescaling. Smoothed states are equivariant: smoothing
+/// `c y` under the `c`-scaled model returns `c` times the smoothed states
+/// of `y`, and `c^2` times their covariances.
+#[test]
+fn smoothed_moments_are_equivariant_under_rescaling() {
+    let y = local_level_series(31, 90);
+    let c = 1e-6;
+
+    let base = scaled_known_local_level(1.0)
+        .smooth(col(&y).as_ref())
+        .unwrap();
+    let ys: Vec<f64> = y.iter().map(|v| v * c).collect();
+    let scaled = scaled_known_local_level(c)
+        .smooth(col(&ys).as_ref())
+        .expect("smoothing a small-variance series must not fail");
+
+    for t in 0..y.len() {
+        let want_mean = c * base.smoothed_state[t][0];
+        let got_mean = scaled.smoothed_state[t][0];
+        assert!(
+            (got_mean - want_mean).abs() <= 1e-10 * want_mean.abs().max(1e-30),
+            "smoothed_state[{t}]: {got_mean} vs {want_mean}"
+        );
+        let want_cov = c * c * base.smoothed_state_cov[t][(0, 0)];
+        let got_cov = scaled.smoothed_state_cov[t][(0, 0)];
+        assert!(
+            (got_cov - want_cov).abs() <= 1e-10 * want_cov.abs(),
+            "smoothed_state_cov[{t}]: {got_cov} vs {want_cov}"
+        );
+    }
+}
+
+/// A genuinely degenerate model — zero observation noise, zero state noise,
+/// zero initial covariance — makes every prediction variance exactly zero,
+/// so every observed element is skipped and the log-likelihood is an empty
+/// sum. That must be an error, never `Ok(0.0)`.
+///
+/// This is the residual case the relative floor cannot rescue: the problem
+/// is the model, not the units, and the message has to say so.
+#[test]
+fn an_entirely_uninformative_sample_is_an_error_not_zero() {
+    let one = Mat::from_fn(1, 1, |_, _| 1.0);
+    let degenerate = LinearGaussianSSM::builder(1, 1, 1)
+        .z(one.clone())
+        .h(Mat::zeros(1, 1))
+        .t(one.clone())
+        .r(one)
+        .q(Mat::zeros(1, 1))
+        .initialization(Initialization::Known {
+            a1: vec![0.0],
+            p1: Mat::zeros(1, 1),
+        })
+        .build()
+        .unwrap();
+
+    let y = local_level_series(3, 40);
+    let err = degenerate
+        .loglike(col(&y).as_ref())
+        .expect_err("a fully degenerate model must not report a likelihood");
+    assert_eq!(err, SsmError::NoInformation);
+
+    // The message has to name the cause and steer away from the wrong fix.
+    let msg = err.to_string();
+    for needle in [
+        "uninformative",
+        "prediction variance",
+        "empty sum",
+        "rescaling y will not change this",
+        "degenerate model",
+    ] {
+        assert!(
+            msg.contains(needle),
+            "the error message must contain {needle:?}: {msg}"
+        );
+    }
+}
+
+/// Rescaling never turns the empty-sample error on or off: it is a property
+/// of the model, and the message says as much. A model that errors at unit
+/// scale errors at every scale, and one that works at unit scale works at
+/// every scale — which is the whole point of a relative tolerance.
+#[test]
+fn the_empty_sample_verdict_is_scale_invariant() {
+    let y = local_level_series(3, 40);
+    let one = Mat::from_fn(1, 1, |_, _| 1.0);
+
+    for k in -4..=8 {
+        let c = 10f64.powi(-k);
+        let ys: Vec<f64> = y.iter().map(|v| v * c).collect();
+
+        let degenerate = LinearGaussianSSM::builder(1, 1, 1)
+            .z(one.clone())
+            .h(Mat::zeros(1, 1))
+            .t(one.clone())
+            .r(one.clone())
+            .q(Mat::zeros(1, 1))
+            .initialization(Initialization::Known {
+                a1: vec![0.0],
+                p1: Mat::zeros(1, 1),
+            })
+            .build()
+            .unwrap();
+        assert_eq!(
+            degenerate.loglike(col(&ys).as_ref()),
+            Err(SsmError::NoInformation),
+            "c = {c:e}: the degenerate model stopped erroring"
+        );
+
+        assert!(
+            scaled_known_local_level(c)
+                .loglike(col(&ys).as_ref())
+                .is_ok(),
+            "c = {c:e}: a well-posed model started erroring"
+        );
+    }
+}
+
+/// An all-missing `y` is *not* the empty-sample error. NaN is the
+/// documented encoding for "missing", so running the recursions with
+/// nothing to condition on is an explicit request, and the log-likelihood
+/// of no observations really is zero. Keeping these two cases distinct is
+/// deliberate; this test is what stops them being merged by accident.
+#[test]
+fn an_all_missing_series_is_still_a_legitimate_zero() {
+    let model = LinearGaussianSSM::local_level(0.16, 0.49).unwrap();
+    let y = vec![f64::NAN; 25];
+    let out = model
+        .filter(col(&y).as_ref())
+        .expect("an all-missing series is a valid, if empty, filtering problem");
+    assert_eq!(out.loglik, 0.0);
+    // The recursions still ran: the predicted covariance grew by Q each
+    // period, so this is a real forward pass and not an early exit.
+    assert_eq!(out.predicted_state.len(), y.len() + 1);
+}
+
+/// A partially informative sample is not an error. Only a *completely*
+/// empty effective sample is, so an ordinary missing stretch — or one
+/// genuinely singular element among many good ones — still filters.
+#[test]
+fn a_partially_missing_series_still_filters() {
+    let model = LinearGaussianSSM::local_level(0.16, 0.49).unwrap();
+    let mut y = local_level_series(17, 60);
+    for v in y.iter_mut().take(30).skip(10) {
+        *v = f64::NAN;
+    }
+    let out = model.filter(col(&y).as_ref()).unwrap();
+    assert!(out.loglik.is_finite() && out.loglik != 0.0);
+}
+
+// ---------------------------------------------------------------------
+// Multi-state: the class of scale bug that `m = 1` cannot see.
+// ---------------------------------------------------------------------
+
+/// [`scaled_known_local_level`] with `c = 1`, plus a second state that
+/// **cannot influence `y`**: `Z = [1, 0]` does not load on it and `T` is
+/// diagonal, so it never feeds into state 1 either. Its initial variance is
+/// `v2` and it evolves as `alpha_2,t+1 = t22 alpha_2,t + eta_2` with
+/// `Var(eta_2) = q2`.
+///
+/// Whatever `(v2, t22, q2)` are, the observations have exactly the law of
+/// the one-state model — so the log-likelihood is pinned to the last bit,
+/// with no tolerance argument to make.
+fn local_level_plus_nuisance(v2: f64, t22: f64, q2: f64) -> LinearGaussianSSM {
+    LinearGaussianSSM::builder(1, 2, 2)
+        .z(Mat::from_fn(1, 2, |_, j| if j == 0 { 1.0 } else { 0.0 }))
+        .h(Mat::from_fn(1, 1, |_, _| 0.16))
+        .t(Mat::from_fn(2, 2, |i, j| match (i, j) {
+            (0, 0) => 1.0,
+            (1, 1) => t22,
+            _ => 0.0,
+        }))
+        .r(Mat::from_fn(2, 2, |i, j| if i == j { 1.0 } else { 0.0 }))
+        .q(Mat::from_fn(2, 2, |i, j| match (i, j) {
+            (0, 0) => 0.49,
+            (1, 1) => q2,
+            _ => 0.0,
+        }))
+        .initialization(Initialization::Known {
+            a1: vec![0.0, 0.0],
+            p1: Mat::from_fn(2, 2, |i, j| match (i, j) {
+                (0, 0) => 2.0,
+                (1, 1) => v2,
+                _ => 0.0,
+            }),
+        })
+        .build()
+        .expect("the local level plus a nuisance state is a valid model")
+}
+
+/// **A state the observation equation does not load on cannot change the
+/// answer** — not by a bit, and not at any variance.
+///
+/// This is the multi-state analogue of the scale sweep: instead of moving
+/// the scale of `y`, it moves the scale of a state that provably does not
+/// enter `y`, over fifteen decades. A reference scale taken over all states
+/// (`||Z||_1^2 max_j P_jj`) fails here: at `v2 = 1e10` it drops the tail of
+/// the sample, and past `1e11` it drops everything and raises
+/// `NoInformation` on a model whose observed states are entirely healthy
+/// (`H = 0.16`, `Q_11 = 0.49`, `P_1,11 = 2`).
+#[test]
+fn a_nuisance_state_cannot_change_the_likelihood() {
+    let y = local_level_series(11, 100);
+    let truth = scaled_known_local_level(1.0)
+        .loglike(col(&y).as_ref())
+        .expect("the one-state likelihood is well defined");
+
+    for k in 0..=15 {
+        let v2 = 10f64.powi(k);
+        let model = local_level_plus_nuisance(v2, 1.0, 0.0);
+        let got = model
+            .loglike(col(&y).as_ref())
+            .unwrap_or_else(|e| panic!("v2 = 1e{k}: an irrelevant state broke the filter: {e}"));
+        let rel = (got - truth).abs() / truth.abs();
+        assert!(
+            rel <= 1e-13,
+            "v2 = 1e{k}: loglik {got} vs the one-state truth {truth} (rel {rel:e}) — \
+             a state y does not depend on moved the likelihood"
+        );
+
+        // And the Joseph-form matrix filter, which has no rank floor at
+        // all, agrees: the univariate path is not merely self-consistent.
+        let oracle = model
+            .filter_matrix(col(&y).as_ref())
+            .expect("the matrix filter accepts this proper initialization")
+            .loglik;
+        let rel_oracle = (got - oracle).abs() / oracle.abs();
+        assert!(
+            rel_oracle <= 1e-10,
+            "v2 = 1e{k}: univariate {got} vs Joseph-form matrix filter {oracle} \
+             (rel {rel_oracle:e})"
+        );
+    }
+}
+
+/// The same nuisance state, but *decaying* (`t22 = 0.5`, `q2 = 0`), so its
+/// variance falls through the whole sample instead of sitting still.
+///
+/// This is the shape that brings back the original defect's worst symptom.
+/// When the reference scale tracks the largest variance over all states, a
+/// falling nuisance variance means observations cross the threshold
+/// *mid-sample*: the opening ones are kept and the rest are dropped, and
+/// the filter returns a finite, plausible, wrong number with no error and
+/// no NaN — exactly the partial silent drop this whole change exists to
+/// remove. Measured with that scale on this fixture: `-93.408` at
+/// `v2 = 1e12` and `-92.067` at `1e13`, against a truth of `-96.189`.
+#[test]
+fn a_decaying_nuisance_state_cannot_silently_drop_observations() {
+    let y = local_level_series(11, 100);
+    let truth = scaled_known_local_level(1.0)
+        .loglike(col(&y).as_ref())
+        .expect("the one-state likelihood is well defined");
+
+    for k in 0..=15 {
+        let v2 = 10f64.powi(k);
+        let got = local_level_plus_nuisance(v2, 0.5, 0.0)
+            .loglike(col(&y).as_ref())
+            .unwrap_or_else(|e| panic!("v2 = 1e{k}: a decaying nuisance state errored: {e}"));
+        let rel = (got - truth).abs() / truth.abs();
+        assert!(
+            rel <= 1e-13,
+            "v2 = 1e{k}: loglik {got} vs the one-state truth {truth} (rel {rel:e}) — \
+             observations were dropped partway through the sample"
+        );
+    }
+}
+
+/// Two independent AR(1) components observed as their sum, written in
+/// state coordinates `alpha~ = S^{-1} alpha` with `S = diag(1, x)`.
+///
+/// `x = 1` is the base model. Under the reparametrization `Z~ = Z S`,
+/// `T~ = S^{-1} T S` (unchanged, `T` is diagonal), `R~ = S^{-1} R` and
+/// `P_1~ = S^{-1} P_1 S^{-1}`. Only the *units* of the second state change,
+/// so `y` has exactly the same law for every `x`. `T` is kept diagonal on
+/// purpose: the reparametrization then leaves `T` alone, and any
+/// disagreement between two `x` values is the rank test talking, not the
+/// conditioning of `T~`.
+fn two_component_rescaled(x: f64) -> LinearGaussianSSM {
+    LinearGaussianSSM::builder(1, 2, 2)
+        .z(Mat::from_fn(1, 2, |_, j| if j == 0 { 1.0 } else { x }))
+        .h(Mat::from_fn(1, 1, |_, _| 0.25))
+        .t(Mat::from_fn(2, 2, |i, j| match (i, j) {
+            (0, 0) => 0.9,
+            (1, 1) => 0.5,
+            _ => 0.0,
+        }))
+        .r(Mat::from_fn(2, 2, |i, j| match (i, j) {
+            (0, 0) => 1.0,
+            (1, 1) => 1.0 / x,
+            _ => 0.0,
+        }))
+        .q(Mat::from_fn(2, 2, |i, j| match (i, j) {
+            (0, 0) => 0.30,
+            (1, 1) => 0.20,
+            _ => 0.0,
+        }))
+        .initialization(Initialization::Known {
+            a1: vec![0.0, 0.0],
+            p1: Mat::from_fn(2, 2, |i, j| match (i, j) {
+                (0, 0) => 1.5,
+                (1, 1) => 0.8 / (x * x),
+                _ => 0.0,
+            }),
+        })
+        .build()
+        .expect("the rescaled two-component model is valid")
+}
+
+/// **Rescaling one state coordinate is a change of units, not a change of
+/// model.** The log-likelihood must not notice, over twelve decades of `x`.
+///
+/// This is the invariance the reference scale has to have and
+/// `||Z||_1^2 max_j P_jj` does not: it mixes `Z~_2 = x` with
+/// `P~_{1,11} = 1.5`, two quantities that no longer live in the same units,
+/// and the product `x^2 * 1.5` runs away in one direction while
+/// `P~_{2,22} = 0.8 / x^2` runs away in the other. Both tails of this sweep
+/// fail under it; the cancellation-free `|Z~|' |P~| |Z~|` is invariant by
+/// construction, because rescaling state `a` multiplies `|Z~_a|` and
+/// divides every `|P~_{ab}|` by exactly offsetting factors.
+#[test]
+fn loglik_is_invariant_to_rescaling_one_state_coordinate() {
+    let y = local_level_series(29, 120);
+    let base = two_component_rescaled(1.0)
+        .loglike(col(&y).as_ref())
+        .expect("the base parametrization filters");
+
+    let mut worst: f64 = 0.0;
+    for k in -6..=6 {
+        let x = 10f64.powi(k);
+        let got = two_component_rescaled(x)
+            .loglike(col(&y).as_ref())
+            .unwrap_or_else(|e| panic!("x = 1e{k}: rewriting the state units broke it: {e}"));
+        let rel = (got - base).abs() / base.abs();
+        worst = worst.max(rel);
+        assert!(
+            rel <= 1e-11,
+            "x = 1e{k}: loglik {got} vs the base parametrization {base} (rel {rel:e}) — \
+             the same model in different state units gave a different answer"
+        );
+    }
+    println!("state-coordinate rescaling: worst relative deviation {worst:e}");
+}
+
+/// The local linear trend `y_t = mu_t + beta_t`, `mu_{t+1} = mu_t + beta_t`,
+/// `beta_{t+1} = beta_t`, fully diffuse, in state coordinates
+/// `alpha~ = S^{-1} alpha` with `S = diag(1, s)`: `Z~ = [1, s]`,
+/// `T~ = S^{-1} T S`, `R~ = S^{-1}`.
+///
+/// Two diffuse directions and a `T` that rotates them into `Z`'s line of
+/// sight, so the diffuse period genuinely terminates — at `t = 2`, in every
+/// parametrization.
+fn diffuse_trend_rescaled(s: f64) -> LinearGaussianSSM {
+    LinearGaussianSSM::builder(1, 2, 2)
+        .z(Mat::from_fn(1, 2, |_, j| if j == 0 { 1.0 } else { s }))
+        .h(Mat::from_fn(1, 1, |_, _| 0.36))
+        .t(Mat::from_fn(2, 2, |i, j| match (i, j) {
+            (0, 0) => 1.0,
+            (0, 1) => s,
+            (1, 1) => 1.0,
+            _ => 0.0,
+        }))
+        .r(Mat::from_fn(2, 2, |i, j| match (i, j) {
+            (0, 0) => 1.0,
+            (1, 1) => 1.0 / s,
+            _ => 0.0,
+        }))
+        .q(Mat::from_fn(2, 2, |i, j| match (i, j) {
+            (0, 0) => 0.25,
+            (1, 1) => 0.04,
+            _ => 0.0,
+        }))
+        .initialization(Initialization::Diffuse)
+        .build()
+        .expect("the rescaled diffuse trend is valid")
+}
+
+/// **The diffuse period is a rank count, so its length cannot depend on the
+/// units the states are written in.** `d_diffuse` must be `2` for every `s`.
+///
+/// The likelihood has one wrinkle here and it is worth stating precisely.
+/// `Initialization::Diffuse` sets `P_inf = I` in each model's *own*
+/// coordinates, so the two models carry diffuse priors that differ by
+/// `S S'`. The exact-diffuse contribution `-(ln 2*pi + ln F_inf)/2` is
+/// therefore not invariant — it is the log-density of an improper prior and
+/// shifts by the Jacobian of the change of state variables:
+///
+/// ```text
+/// loglik(s) = loglik(1) - ln|det S| = loglik(1) - ln|s|.
+/// ```
+///
+/// Asserting that exact line, rather than plain equality, is what makes the
+/// test able to fail: a filter that quietly skipped a diffuse element would
+/// still get `d_diffuse` wrong *and* miss the line.
+///
+/// With the all-states reference scale, `s = 1e3` returned `d = 1` and
+/// `s = 1e-5` returned `d = 100` — the diffuse period never terminated —
+/// on the same two models. See the note on the range below.
+#[test]
+fn the_diffuse_period_is_invariant_to_rescaling_one_state_coordinate() {
+    let y = local_level_series(7, 100);
+    let base = diffuse_trend_rescaled(1.0)
+        .filter(col(&y).as_ref())
+        .expect("the base parametrization filters");
+    assert_eq!(
+        base.d_diffuse, 2,
+        "two diffuse states, resolved one per step"
+    );
+
+    // Range note: this sweep stops at `1e-5` and `1e2` because outside it
+    // the *representation* is genuinely lost, not the rank test. `T~` and
+    // `R~` carry factors of `s` and `1/s`, so the recursions themselves
+    // cancel to nothing: at `s = 1e-6` the residual `P_inf` after the
+    // first update is roundoff of order `1e-16` sitting in an entry that
+    // `Z~` weights by 1, against a live `F_inf` of `1e-12` — the signal is
+    // below the noise before any threshold is consulted. What the sweep
+    // does pin is that nothing *else* — no threshold, no reference scale —
+    // narrows the range in which the identity holds.
+    for k in -5..=2 {
+        let s = 10f64.powi(k);
+        let out = diffuse_trend_rescaled(s)
+            .filter(col(&y).as_ref())
+            .unwrap_or_else(|e| panic!("s = 1e{k}: rewriting the state units broke it: {e}"));
+
+        assert_eq!(
+            out.d_diffuse, 2,
+            "s = 1e{k}: the diffuse period changed length ({}) when the states \
+             were rewritten in different units",
+            out.d_diffuse
+        );
+        let want = base.loglik - s.ln();
+        let rel = (out.loglik - want).abs() / want.abs();
+        assert!(
+            rel <= 1e-9,
+            "s = 1e{k}: diffuse loglik {} vs the Jacobian-shifted base {want} (rel {rel:e})",
+            out.loglik
+        );
+    }
+}


### PR DESCRIPTION
`TOLERANCE_DIFFUSE = 1e-10` was an **absolute** floor on the prediction variance `F_*` — a quantity in units of *y* squared. That's a units error, and it made the filter treat every observation of a small-variance series as carrying no information, returning `loglik = 0.0` **successfully**.

Reproduced through the Python layer: `arima_fit` on a series with `sigma2 ~ 1e-14` returned `0.0` with no error and no warning, so a caller could "fit" it and get a meaningless optimum reported as success.

**The total collapse wasn't the worst case.** At an intermediate scale the filter kept the opening observations — whose `P_1` still cleared the floor — and dropped the rest as the variance converged below it, returning **772.13 against a true 1581.34**. A silently 51%-wrong likelihood: finite, plausible, unflagged.

## The fix

A scale-relative floor, with the reference being the cancellation-free quadratic form `|z|' |P| |z|` (`+ H_ii` for `F_*`).

Two earlier candidates were rejected **with measurement, not taste**:
- `dot(|z|, |m_star|)` misses cancellation *inside* `P z` and admits roundoff as a real variance.
- `‖z‖₁² · maxⱼ P_jj` takes the largest variance over **all** states rather than along the direction `z` observes — letting a state the observation equation cannot even load on veto every observation (**89% wrong at v2=1e11**, where the old absolute code was right everywhere).

**The `P_inf` washout test stays absolute.** `P_inf` is a rank indicator, not a variance — it never touches `y`, `H`, or `Q`. There was no units bug at that site, and making it relative only introduced a latent failure for a non-uniform prior like `diag(1e10, 1)`. The doc now records why the three uses don't get the same treatment.

Also: the smoother re-derived the diffuse branch by re-running the threshold test, which a relative test could make disagree with the filter. The branch is now recorded on `ObsStep` and replayed.

## Evidence

- Verified against **`filter_matrix`** — the Joseph-form path that has *no rank floor at all* and therefore cannot have been contaminated by this change. Bit-identical across nine decades below the old threshold.
- **The three statsmodels goldens are bit-unchanged**, proven by evaluating all three candidate scales under a temporary switch and comparing `to_bits()`: local-level loglik `-633.4645636488783` (`0xc083cbb76d2576be`) identical under every one. The change is a *provable* no-op on unit-scale data.
- Closed form `loglik(c·y) = loglik(y) − n·ln(c)` holds to **4.22e-16** through Python, **8.9e-16** in the crate sweep across 22 decades.
- **Teeth, both directions:** restoring the absolute floor fails 5 of 12 scale tests; using the rejected `max_diag` scale fails exactly the 4 new multi-state ones. Neither set subsumes the other.

## Why it got through

All 8 original scale tests used a **single-state** model, where `‖z‖₁ = 1` and `max_diag(P) == z'Pz` are the same number — so direction-blindness was structurally invisible. Four multi-state tests now close that gap: nuisance-state, decaying-nuisance, state-coordinate invariance, and diffuse-period invariance.

## Known residual, filed not hidden

The diffuse period terminates on a **norm** test over `P_inf`, and `T` propagates `P_inf`, so a reparametrized model can end the diffuse period one step early (0.47 nats). Absolute and relative fail this **identically** — measured both — so it's pre-existing, not caused by this work. The fix is rank-counting termination, deliberately not shipped inside a repair commit.

## Gates

1096 Rust (0 failed) · 562 Python · `cargo fmt` · `clippy -D warnings` · `mkdocs --strict`. tsecon-ssm 18 → 22 tests; tsecon-arima 42; tsecon-bayes 42.

Unblocks SARIMA (`tsecon-arima` depends on this crate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)